### PR TITLE
Updated wrangler config to work with Wrangler CLI 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ An example of stateless Discord Bot using Slash Commands feature and Cloudflare 
 1. Clone this repository.
 2. Copy `wrangler.example.toml`, then rename it to `wranger.toml` .
 3. Edit the file, filling `account_id` and `vars.PUBLIC_KEY` .
-4. Build the current package and all its dependencies using `cargo b -r` (Release version)
-5. Deploy using `wrangler publish` .
-6. Register your endpoint at Discord Developer Portal.
-7. Create an application command. For example:
+4. Deploy using `wrangler publish` .
+5. Register your endpoint at Discord Developer Portal.
+6. Create an application command. For example:
    ```console
    $ curl \
      -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
@@ -25,4 +24,4 @@ An example of stateless Discord Bot using Slash Commands feature and Cloudflare 
      -d '{"name":"hello","description":"The bot will say \"Hello, world!\"."}' \
      "https://discord.com/api/v8/applications/${APPLICATION_ID}/commands"
    ```
-1. Done!
+8. Done!

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ An example of stateless Discord Bot using Slash Commands feature and Cloudflare 
 
 ## 📦 Installation
 1. Clone this repository.
-1. Copy `wrangler.example.toml`, then rename it to `wranger.toml` .
-1. Edit the file, filling `account_id` and `vars.PUBLIC_KEY` .
-1. Deploy using `wrangler publish` .
-1. Register your endpoint at Discord Developer Portal.
-1. Create an application command. For example:
+2. Copy `wrangler.example.toml`, then rename it to `wranger.toml` .
+3. Edit the file, filling `account_id` and `vars.PUBLIC_KEY` .
+4. Build the current package and all its dependencies using `cargo b -r` (Release version)
+5. Deploy using `wrangler publish` .
+6. Register your endpoint at Discord Developer Portal.
+7. Create an application command. For example:
    ```console
    $ curl \
      -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -1,9 +1,8 @@
 name = "stateless-discord-bot"
-type = "rust"
 account_id = "{{ACCOUNT_ID}}"
 workers_dev = true
-route = ""
-zone_id = ""
+compatibility_date = "2022-08-04"
+main="./worker/worker.js"
 
 [vars]
 PUBLIC_KEY = "{{PUBLIC_KEY}}"


### PR DESCRIPTION
Closes #4 

There have been some changes in Wrangler 2.x CLI which doesn't let the deployment to succeed when using the `wrangler publish` command.

This PR should fix it.

### Success
```
wrangler publish
 ⛅️ wrangler 2.0.28
--------------------
Retrieving cached values for userId from ../../../../node_modules/.cache/wrangler
Your worker has access to the following bindings:
- Vars:
  - PUBLIC_KEY: "..."
Total Upload: 0.92 KiB / gzip: 0.43 KiB
Uploaded stateless-discord-bot (0.43 sec)
Published stateless-discord-bot (0.28 sec)
  https://stateless-discord-bot.<domanin>.workers.dev
```

